### PR TITLE
Add bin to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
     "squizlabs/php_codesniffer": "^3.7",
     "guzzlehttp/psr7": "^2.4",
     "mikey179/vfsstream": "^1.6.7"
-  }
+  },
+  "bin": [
+    "bin/membrane-router"
+  ]
 }


### PR DESCRIPTION
## Change

Add "bin" section to composer.json 

### Reasoning

Allows membrane-router to be called from vendor/bin when imported as a package.