### PR TITLE
Update vfsstream to 1.6.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     "phpstan/phpstan": "^1.8",
     "squizlabs/php_codesniffer": "^3.7",
     "guzzlehttp/psr7": "^2.4",
-    "mikey179/vfsstream": "^1.6"
+    "mikey179/vfsstream": "^1.6.7"
   }
 }


### PR DESCRIPTION
This solves issue with minimum versions of PHPUnit tests in CI workflow