### PR TITLE
Update ReaderTest to solve deprecations

### DIFF
--- a/tests/Reader/OpenAPIFileReaderTest.php
+++ b/tests/Reader/OpenAPIFileReaderTest.php
@@ -7,18 +7,21 @@ namespace Membrane\OpenAPIRouter\Reader;
 use cebe\openapi\exceptions\UnresolvableReferenceException;
 use cebe\openapi\spec\OpenApi;
 use Membrane\OpenAPIRouter\Exception\CannotReadOpenAPI;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\ParseException;
+use TypeError;
 
-/**
- * @covers \Membrane\OpenAPIRouter\Reader\OpenAPIFileReader
- * @covers Membrane\OpenAPIRouter\Exception\CannotReadOpenAPI
- */
+#[CoversClass(OpenAPIFileReader::class)]
+#[CoversClass(CannotReadOpenAPI::class)]
 class OpenAPIFileReaderTest extends TestCase
 {
     public const FIXTURES = __DIR__ . '/../fixtures/';
 
-    public function dataSetsThatThrowExceptions(): array
+    public static function dataSetsThatThrowExceptions(): array
     {
         return [
             'Non-existent file throws CannotReadOpenAPI::fileNotFound' => [
@@ -34,15 +37,15 @@ class OpenAPIFileReaderTest extends TestCase
                 __FILE__,
             ],
             'Empty .json file throws CannotReadOpenAPI::cannotParse' => [
-                CannotReadOpenAPI::cannotParse('empty.json', new \TypeError()),
+                CannotReadOpenAPI::cannotParse('empty.json', new TypeError()),
                 self::FIXTURES . 'empty.json',
             ],
             'Empty .yml file throws CannotReadOpenAPI::cannotParse' => [
-                CannotReadOpenAPI::cannotParse('empty.yml', new \TypeError()),
+                CannotReadOpenAPI::cannotParse('empty.yml', new TypeError()),
                 self::FIXTURES . 'empty.yml',
             ],
             '.json file in invalid json format throws CannotReadOpenAPI::cannotParse' => [
-                CannotReadOpenAPI::cannotParse('invalid.json', new \TypeError()),
+                CannotReadOpenAPI::cannotParse('invalid.json', new TypeError()),
                 self::FIXTURES . 'invalid.json',
             ],
             '.yaml file in invalid yaml format throws CannotReadOpenAPI::cannotParse' => [
@@ -60,10 +63,8 @@ class OpenAPIFileReaderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatThrowExceptions
-     */
+    #[Test, TestDox('handles different exceptions for failing to read the OpenAPI Spec')]
+    #[DataProvider('dataSetsThatThrowExceptions')]
     public function exceptionHandlingTest(CannotReadOpenAPI $expected, string $filePath): void
     {
         self::expectExceptionObject($expected);
@@ -71,7 +72,7 @@ class OpenAPIFileReaderTest extends TestCase
         (new OpenAPIFileReader())->readFromAbsoluteFilePath($filePath);
     }
 
-    /** @test */
+    #[Test, TestDox('Can read OpenAPIs from absolute filepaths')]
     public function readFromAbsoluteFilePathTest(): void
     {
         $expected = OpenApi::class;


### PR DESCRIPTION
Solves one more deprecations within the OpenAPIFileReader test as well as update it to use attributes.