### PR TITLE
Add ignoreServers option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": "^8.1.0",
     "cebe/php-openapi": "^1.7",
-    "membrane/openapi-reader": "^2.0.0",
+    "membrane/openapi-reader": "2.1.0",
     "psr/http-message": "^1.0 || ^2.0",
     "psr/log": "^3.0",
     "symfony/console": "^6.0 || ^7.0"

--- a/src/Console/Command/CacheOpenAPIRoutes.php
+++ b/src/Console/Command/CacheOpenAPIRoutes.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Membrane\OpenAPIRouter\Console\Command;
 
-use Membrane\OpenAPIRouter\Console\Service\CacheOpenAPIRoutes as CacheOpenAPIRoutesService;
+use Membrane\OpenAPIRouter\Console\Service;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -20,29 +22,52 @@ class CacheOpenAPIRoutes extends Command
 {
     protected function configure(): void
     {
-        self::addArgument(
-            'openAPI',
-            InputArgument::REQUIRED,
-            'The absolute filepath to your OpenAPI'
-        );
-        self::addArgument(
-            'destination',
-            InputArgument::OPTIONAL,
-            'The filepath for the generated route collection',
-            getcwd() . '/cache/routes.php'
-        );
+        $this->setDefinition(new InputDefinition([
+            new InputArgument(
+                name: 'openAPI',
+                mode: InputArgument::REQUIRED,
+                description: 'The absolute filepath to your OpenAPI'
+            ),
+            new InputArgument(
+                name: 'destination',
+                mode: InputArgument::OPTIONAL,
+                description: 'The filepath for the generated route collection',
+                default: getcwd() . '/cache/routes.php'
+            ),
+            new InputOption(
+                name: 'ignore-servers',
+                description: 'ignore servers, only use the default "/" server',
+                mode: InputOption::VALUE_NONE,
+            ),
+            // @todo add support for this in the reader first
+            // new InputOption(
+            //     name: 'with-hostless-fallback',
+            //     description: 'add the default "/" server, if not already specified',
+            // ),
+        ]));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $openAPIFilePath = $input->getArgument('openAPI');
         assert(is_string($openAPIFilePath));
+
         $destination = $input->getArgument('destination');
         assert(is_string($destination));
 
-        $logger = new ConsoleLogger($output);
-        $service = new CacheOpenAPIRoutesService($logger);
+        $ignoreServers = $input->getOption('ignore-servers');
+        assert(is_bool($ignoreServers));
+        // @todo add support this in the reader first
+        // $hostlessFallback = $input->getOption('with-hostless-fallback');
 
-        return $service->cache($openAPIFilePath, $destination) ? Command::SUCCESS : Command::FAILURE;
+        $logger = new ConsoleLogger($output);
+
+        return (new Service\CacheOpenAPIRoutes($logger))->cache(
+            $openAPIFilePath,
+            $destination,
+            $ignoreServers,
+            // @todo add support this in the reader first
+            // $hostlessFallback,
+        ) ? Command::SUCCESS : Command::FAILURE;
     }
 }

--- a/src/Console/Service/CacheOpenAPIRoutes.php
+++ b/src/Console/Service/CacheOpenAPIRoutes.php
@@ -19,8 +19,13 @@ class CacheOpenAPIRoutes
     ) {
     }
 
-    public function cache(string $openAPIFilePath, string $cacheDestination): bool
-    {
+    public function cache(
+        string $openAPIFilePath,
+        string $cacheDestination,
+        bool $ignoreServers = false,
+        //@todo add support for this in the reader first
+        // bool $hostlessFallback,
+    ): bool {
         $existingFilePath = $cacheDestination;
         while (!file_exists($existingFilePath)) {
             $existingFilePath = dirname($existingFilePath);
@@ -37,6 +42,15 @@ class CacheOpenAPIRoutes
             $this->logger->error($e->getMessage());
             return false;
         }
+
+        if ($ignoreServers) {
+            $openApi = $openApi->withoutServers();
+        }
+
+        //@todo add support for this in reader first
+        // if ($hostlessFallback) {
+        //     $openApi = $openApi->withHostlessFallback();
+        // }
 
         try {
             $routeCollection = (new RouteCollector())->collect($openApi);

--- a/tests/Console/Service/CacheOpenAPIRoutesTest.php
+++ b/tests/Console/Service/CacheOpenAPIRoutesTest.php
@@ -9,9 +9,11 @@ use Membrane\OpenAPIRouter\Exception\CannotCollectRoutes;
 use Membrane\OpenAPIRouter\Route;
 use Membrane\OpenAPIRouter\RouteCollection;
 use Membrane\OpenAPIRouter\RouteCollector;
+use Membrane\OpenAPIRouter\Tests\Fixtures\ProvidesApiAndRoutes;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
@@ -66,222 +68,33 @@ class CacheOpenAPIRoutesTest extends TestCase
         self::assertFalse($this->sut->cache($filePath, $this->root . '/cache/routes.php'));
     }
 
-    public static function successfulExecutionProvider(): array
-    {
-        $petStoreRoutes = new RouteCollection([
-            'hosted' => [
-                'static' => [
-                    'http://petstore.swagger.io/api' => [
-                        'static' => [
-                            '/pets' => [
-                                'get' => 'findPets',
-                                'post' => 'addPet',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|/pets/([^/]+)(*MARK:/pets/{id}))$#',
-                            'paths' => [
-                                '/pets/{id}' => [
-                                    'get' => 'find pet by id',
-                                    'delete' => 'deletePet',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-                'dynamic' => [
-                    'regex' => '#^(?|)#',
-                    'servers' => [],
-                ],
-            ],
-            'hostless' => [
-                'static' => [],
-                'dynamic' => [
-                    'regex' => '#^(?|)#',
-                    'servers' => [],
-                ],
-            ],
-        ]);
-        $weirdAndWonderfulRoutes = new RouteCollection([
-            'hosted' => [
-                'static' => [
-                    'http://weirdest.com' => [
-                        'static' => [
-                            '/however' => [
-                                'put' => 'put-however',
-                                'post' => 'post-however',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|/and/([^/]+)(*MARK:/and/{name}))$#',
-                            'paths' => [
-                                '/and/{name}' => [
-                                    'get' => 'get-and',
-                                ],
-                            ],
-                        ],
-                    ],
-                    'http://weirder.co.uk' => [
-                        'static' => [
-                            '/however' => [
-                                'get' => 'get-however',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|/and/([^/]+)(*MARK:/and/{name}))$#',
-                            'paths' => [
-                                '/and/{name}' => [
-                                    'put' => 'put-and',
-                                    'post' => 'post-and',
-                                ],
-                            ],
-                        ],
-                    ],
-                    'http://wonderful.io' => [
-                        'static' => [
-                            '/or' => [
-                                'post' => 'post-or',
-                            ],
-                            '/xor' => [
-                                'delete' => 'delete-xor',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|)$#',
-                            'paths' => [],
-                        ],
-                    ],
-                    'http://wonderful.io/and' => [
-                        'static' => [
-                            '/or' => [
-                                'post' => 'post-or',
-                            ],
-                            '/xor' => [
-                                'delete' => 'delete-xor',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|)$#',
-                            'paths' => [],
-                        ],
-                    ],
-                    'http://wonderful.io/or' => [
-                        'static' => [
-                            '/or' => [
-                                'post' => 'post-or',
-                            ],
-                            '/xor' => [
-                                'delete' => 'delete-xor',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|)$#',
-                            'paths' => [],
-                        ],
-                    ],
-                ],
-                'dynamic' => [
-                    'regex' => '#^(?|http://weird.io/([^/]+)(*MARK:http://weird.io/{conjunction}))#',
-                    'servers' => [
-                        'http://weird.io/{conjunction}' => [
-                            'static' => [
-                                '/or' => [
-                                    'post' => 'post-or',
-                                ],
-                                '/xor' => [
-                                    'delete' => 'delete-xor',
-                                ],
-                            ],
-                            'dynamic' => [
-                                'regex' => '#^(?|)$#',
-                                'paths' => [],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'hostless' => [
-                'static' => [
-                    '' => [
-                        'static' => [
-                            '/or' => [
-                                'post' => 'post-or',
-                            ],
-                            '/xor' => [
-                                'delete' => 'delete-xor',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|)$#',
-                            'paths' => [],
-                        ],
-                    ],
-                    '/v1' => [
-                        'static' => [
-                            '/or' => [
-                                'post' => 'post-or',
-                            ],
-                            '/xor' => [
-                                'delete' => 'delete-xor',
-                            ],
-                        ],
-                        'dynamic' => [
-                            'regex' => '#^(?|)$#',
-                            'paths' => [],
-                        ],
-                    ],
-                ],
-                'dynamic' => [
-                    'regex' => '#^(?|/([^/]+)(*MARK:/{version}))#',
-                    'servers' => [
-                        '/{version}' => [
-                            'static' => [
-                                '/or' => [
-                                    'post' => 'post-or',
-                                ],
-                                '/xor' => [
-                                    'delete' => 'delete-xor',
-                                ],
-                            ],
-                            'dynamic' => [
-                                'regex' => '#^(?|)$#',
-                                'paths' => [],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-        return [
-            'successfully routes petstore-expanded.json' => [
-                __DIR__ . '/../../fixtures/docs/petstore-expanded.json',
-                vfsStream::url('root/cache/routes.php'),
-                $petStoreRoutes
-            ],
-            'successfully routes the WeirdAndWonderful.json' => [
-                __DIR__ . '/../../fixtures/WeirdAndWonderful.json',
-                vfsStream::url('root/cache/routes.php'),
-                $weirdAndWonderfulRoutes
-            ],
-            'successfully routes the WeirdAndWonderful.json and caches in a nested directory' => [
-                __DIR__ . '/../../fixtures/WeirdAndWonderful.json',
-                vfsStream::url('root/cache/nested-cache/nester-cache/nestest-cache/routes.php'),
-                $weirdAndWonderfulRoutes
-            ]
-        ];
+    #[Test]
+    #[DataProviderExternal(ProvidesApiAndRoutes::class, 'defaultBehaviour')]
+    public function itCachesRoutes(
+        string $apiPath,
+        RouteCollection $expected,
+    ): void {
+        $cachePath = vfsStream::url('root/cache/routes.php');
+
+        self::assertTrue($this->sut->cache($apiPath, $cachePath));
+
+        $actualRouteCollection = eval('?>' . file_get_contents($cachePath));
+
+        self::assertEquals($expected, $actualRouteCollection);
     }
 
     #[Test]
-    #[DataProvider('successfulExecutionProvider')]
-    public function successfulExecutionTest(
-        string $openAPI,
-        string $destination,
-        RouteCollection $expectedRouteCollection
+    #[DataProviderExternal(ProvidesApiAndRoutes::class, 'ignoringServers')]
+    public function itCachesRoutesIgnoringServers(
+        string $apiPath,
+        RouteCollection $expected
     ): void {
-        self::assertTrue($this->sut->cache($openAPI, $destination));
+        $cachePath = vfsStream::url('root/cache/routes.php');
 
-        $actualRouteCollection = eval('?>' . file_get_contents($destination));
+        self::assertTrue($this->sut->cache($apiPath, $cachePath, true));
 
-        self::assertEquals($expectedRouteCollection, $actualRouteCollection);
+        $actual = eval('?>' . file_get_contents($cachePath));
+
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/fixtures/ProvidesApiAndRoutes.php
+++ b/tests/fixtures/ProvidesApiAndRoutes.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPIRouter\Tests\Fixtures;
+
+use Generator;
+use Membrane\OpenAPIRouter\RouteCollection;
+
+final class ProvidesApiAndRoutes
+{
+    private const PETSTORE_EXPANDED = __DIR__ . '/docs/petstore-expanded.json';
+    private const WEIRD_AND_WONDERFUL = __DIR__ . '/WeirdAndWonderful.json';
+
+    public static function defaultBehaviour(): Generator
+    {
+        yield 'petstore expanded' => [self::PETSTORE_EXPANDED, new RouteCollection([
+            'hosted' => [
+                'static' => ['http://petstore.swagger.io/api' => [
+                    'static' => [
+                        '/pets' => ['get' => 'findPets', 'post' => 'addPet'],
+                    ],
+                    'dynamic' => [
+                        'regex' => '#^(?|/pets/([^/]+)(*MARK:/pets/{id}))$#',
+                        'paths' => [
+                            '/pets/{id}' => ['get' => 'find pet by id', 'delete' => 'deletePet'],
+                        ],
+                    ],
+                ]],
+                'dynamic' => ['regex' => '#^(?|)#', 'servers' => []],
+            ],
+            'hostless' => ['static' => [], 'dynamic' => ['regex' => '#^(?|)#', 'servers' => []]],
+        ])];
+
+        yield 'weird and wonderful' => [self::WEIRD_AND_WONDERFUL, new RouteCollection([
+            'hosted' => [
+                'static' => [
+                    'http://weirdest.com' => [
+                        'static' => [
+                            '/however' => ['put' => 'put-however', 'post' => 'post-however'],
+                        ],
+                        'dynamic' => [
+                            'regex' => '#^(?|/and/([^/]+)(*MARK:/and/{name}))$#',
+                            'paths' => [
+                                '/and/{name}' => ['get' => 'get-and']
+                            ],
+                        ],
+                    ],
+                    'http://weirder.co.uk' => [
+                        'static' => [
+                            '/however' => ['get' => 'get-however']
+                        ],
+                        'dynamic' => [
+                            'regex' => '#^(?|/and/([^/]+)(*MARK:/and/{name}))$#',
+                            'paths' => [
+                                '/and/{name}' => ['put' => 'put-and', 'post' => 'post-and'],
+                            ],
+                        ],
+                    ],
+                    'http://wonderful.io' => [
+                        'static' => [
+                            '/or' => ['post' => 'post-or'],
+                            '/xor' => ['delete' => 'delete-xor'],
+                        ],
+                        'dynamic' => ['regex' => '#^(?|)$#', 'paths' => []],
+                    ],
+                    'http://wonderful.io/and' => [
+                        'static' => [
+                            '/or' => ['post' => 'post-or'],
+                            '/xor' => ['delete' => 'delete-xor'],
+                        ],
+                        'dynamic' => [
+                            'regex' => '#^(?|)$#',
+                            'paths' => [],
+                        ],
+                    ],
+                    'http://wonderful.io/or' => [
+                        'static' => [
+                            '/or' => ['post' => 'post-or'],
+                            '/xor' => ['delete' => 'delete-xor'],
+                        ],
+                        'dynamic' => ['regex' => '#^(?|)$#', 'paths' => []],
+                    ],
+                ],
+                'dynamic' => [
+                    'regex' => '#^(?|http://weird.io/([^/]+)(*MARK:http://weird.io/{conjunction}))#',
+                    'servers' => ['http://weird.io/{conjunction}' => [
+                        'static' => [
+                            '/or' => ['post' => 'post-or'],
+                            '/xor' => ['delete' => 'delete-xor'],
+                        ],
+                        'dynamic' => ['regex' => '#^(?|)$#', 'paths' => []],
+                    ]],
+                ],
+            ],
+            'hostless' => [
+                'static' => [
+                    '' => [
+                        'static' => [
+                            '/or' => ['post' => 'post-or'],
+                            '/xor' => ['delete' => 'delete-xor'],
+                        ],
+                        'dynamic' => ['regex' => '#^(?|)$#', 'paths' => []],
+                    ],
+                    '/v1' => [
+                        'static' => [
+                            '/or' => ['post' => 'post-or'],
+                            '/xor' => ['delete' => 'delete-xor'],
+                        ],
+                        'dynamic' => ['regex' => '#^(?|)$#', 'paths' => []],
+                    ],
+                ],
+                'dynamic' => [
+                    'regex' => '#^(?|/([^/]+)(*MARK:/{version}))#',
+                    'servers' => ['/{version}' => [
+                        'static' => [
+                            '/or' => ['post' => 'post-or'],
+                            '/xor' => ['delete' => 'delete-xor'],
+                        ],
+                        'dynamic' => ['regex' => '#^(?|)$#', 'paths' => []],
+                    ]],
+                ],
+            ],
+        ])];
+    }
+
+    public static function ignoringServers(): Generator
+    {
+        yield 'petstore-expanded, ignoring servers' => [self::PETSTORE_EXPANDED, new RouteCollection([
+            'hosted' => ['static' => [], 'dynamic' => ['regex' => '#^(?|)#', 'servers' => []]],
+            'hostless' => [
+                'static' => ['' => [
+                    'static' => [
+                        '/pets' => ['get' => 'findPets', 'post' => 'addPet'],
+                    ],
+                    'dynamic' => [
+                        'regex' => '#^(?|/pets/([^/]+)(*MARK:/pets/{id}))$#',
+                        'paths' => [
+                            '/pets/{id}' => ['get' => 'find pet by id', 'delete' => 'deletePet'],
+                        ],
+                    ],
+                ]],
+                'dynamic' => ['regex' => '#^(?|)#', 'servers' => []],
+            ],
+        ])];
+
+        yield 'weird-and-wonderful, ignoring servers' => [self::WEIRD_AND_WONDERFUL, new RouteCollection([
+            'hosted' => ['static' => [], 'dynamic' => ['regex' => '#^(?|)#', 'servers' => []]],
+            'hostless' => [
+                'static' => ['' => [
+                    'static' => [
+                        '/or' => [
+                            'post' => 'post-or',
+                        ],
+                        '/xor' => [
+                            'delete' => 'delete-xor',
+                        ],
+                        '/however' => [
+                            'get' => 'get-however',
+                            'put' => 'put-however',
+                            'post' => 'post-however',
+                        ],
+                    ],
+                    'dynamic' => [
+                        'regex' => '#^(?|/and/([^/]+)(*MARK:/and/{name}))$#',
+                        'paths' => [
+                            '/and/{name}' => [
+                                'get' => 'get-and',
+                                'put' => 'put-and',
+                                'post' => 'post-and',
+                            ],
+                        ]
+                    ],
+                ]],
+                'dynamic' => ['regex' => '#^(?|)#', 'servers' => []],
+            ],
+        ])];
+    }
+}


### PR DESCRIPTION
Adds an `ignoreServers` argument, which defaults to false to maintain backwards compatibility.

Ignoring servers means that all routes are assumed to only use the default server '/'