### PR TITLE
Support Symfony Console ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     "membrane/openapi-reader": "^2.0.0",
     "psr/http-message": "^1.0 || ^2.0",
     "psr/log": "^3.0",
-    "symfony/console": "^6.2"
+    "symfony/console": "^6.0 || ^7.0"
   },
   "require-dev": {
     "infection/infection": "^0.27.0",
-    "phpunit/phpunit": "^10.2",
-    "phpstan/phpstan": "^1.10.56",
-    "squizlabs/php_codesniffer": "^3.7",
+    "phpunit/phpunit": "^10.5.38",
+    "phpstan/phpstan": "^1.12.7",
+    "squizlabs/php_codesniffer": "^3.5.4",
     "guzzlehttp/psr7": "^2.4",
     "mikey179/vfsstream": "^1.6.7"
   },

--- a/src/Console/Command/CacheOpenAPIRoutes.php
+++ b/src/Console/Command/CacheOpenAPIRoutes.php
@@ -33,7 +33,7 @@ class CacheOpenAPIRoutes extends Command
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $openAPIFilePath = $input->getArgument('openAPI');
         assert(is_string($openAPIFilePath));


### PR DESCRIPTION
Resolves #27 

Adds support for Symfony\Console 7.0

Symfony\Component\Console\Command swapped its `execute` method from relying on an annotation to using an actual type hint. 