### PR TITLE
Remove explicit dependency on cebe library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
   },
   "require": {
     "php": "^8.1.0",
-    "cebe/php-openapi": "^1.7",
     "membrane/openapi-reader": "2.1.0",
     "psr/http-message": "^1.0 || ^2.0",
     "psr/log": "^3.0",


### PR DESCRIPTION
This is no longer used within the router.
No change to behaviour, this is clean up.