### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     }
   },
   "require": {
-    "php": "^8.1.0",
+    "php": "^8.4.0",
     "membrane/openapi-reader": "^3.0",
-    "psr/http-message": "^1.0 || ^2.0",
-    "psr/log": "^3.0",
-    "symfony/console": "^6.0 || ^7.0"
+    "psr/http-message": "^1.1 || ^2.0",
+    "psr/log": "^3.0.2",
+    "symfony/console": "^7.4.11 || ^8.0.11"
   },
   "require-dev": {
     "infection/infection": "^0.27.0",

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     "symfony/console": "^7.4.11 || ^8.0.11"
   },
   "require-dev": {
-    "infection/infection": "^0.27.0",
-    "phpunit/phpunit": "^10.5.38",
-    "phpstan/phpstan": "^2.1.1",
-    "squizlabs/php_codesniffer": "^3.7",
-    "guzzlehttp/psr7": "^2.4",
-    "mikey179/vfsstream": "^1.6.7"
+    "infection/infection": "^0.33.2",
+    "phpunit/phpunit": "^13.1.11",
+    "phpstan/phpstan": "^2.1.55",
+    "squizlabs/php_codesniffer": "^4.0.1",
+    "guzzlehttp/psr7": "^2.10.1",
+    "mikey179/vfsstream": "^1.6.12"
   },
   "bin": [
     "bin/membrane-router"


### PR DESCRIPTION
All dependencies updated to latest versions.
Old major versions updated to latest minor and patch.

PHP updated to 8.4 min to match membrane core.
(Also PHP 8.1 and 8.2 reached EOL)

Dev dependencies have also been updated due to deprecations in one of them.